### PR TITLE
add raw websocket handler for chat messages

### DIFF
--- a/lib/algora/chat/message.ex
+++ b/lib/algora/chat/message.ex
@@ -4,6 +4,15 @@ defmodule Algora.Chat.Message do
   alias Algora.Library.Video
   import Ecto.Changeset
 
+  @derive {Jason.Encoder,
+           only: [
+             :body,
+             :platform,
+             :sender_handle,
+             :sender_name,
+             :sender_avatar_url,
+             :inserted_at
+           ]}
   schema "messages" do
     field :body, :string
     field :platform, :string, virtual: true

--- a/lib/algora_web/endpoint.ex
+++ b/lib/algora_web/endpoint.ex
@@ -12,6 +12,8 @@ defmodule AlgoraWeb.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
+  socket "/chat/:channel_handle", AlgoraWeb.Websockets.ChatSocket
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/lib/algora_web/websockets/chat_socket.ex
+++ b/lib/algora_web/websockets/chat_socket.ex
@@ -1,0 +1,67 @@
+defmodule AlgoraWeb.Websockets.ChatSocket do
+  @moduledoc """
+  `Phoenix.Socket.Transport` implementation for sending chat messages
+  to the client connection.
+  """
+
+  @behaviour Phoenix.Socket.Transport
+
+  require Logger
+
+  alias Algora.{Accounts, Library, Chat}
+
+  @base_mount_path "/chat"
+
+  @spec base_mount_path :: String.t()
+  def base_mount_path, do: @base_mount_path
+
+  @impl true
+  def child_spec(_opts) do
+    %{id: Task, start: {Task, :start_link, [fn -> :ok end]}, restart: :transient}
+  end
+
+  @impl true
+  def connect(%{params: %{"channel_handle" => channel_handle}}) do
+    {:ok, %{channel_handle: channel_handle}}
+  end
+
+  @impl true
+  def init(%{channel_handle: channel_handle}) do
+    user = Accounts.get_user_by!(handle: channel_handle)
+    channel = Library.get_channel!(user)
+    video = Library.get_latest_video(user)
+
+    Library.subscribe_to_channel(channel)
+    if video, do: Chat.subscribe_to_room(video)
+
+    {:ok, %{video: video}}
+  end
+
+  @impl true
+  def handle_in({_message, _opts}, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info({Chat, %Chat.Events.MessageSent{message: message}}, state) do
+    {:push, {:text, Jason.encode!(message)}, state}
+  end
+
+  def handle_info(
+        {Library, %Library.Events.LivestreamStarted{video: video}},
+        state
+      ) do
+    if state.video, do: Chat.unsubscribe_to_room(state.video)
+    Chat.subscribe_to_room(video)
+    {:ok, %{video: video}}
+  end
+
+  def handle_info(_message, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :ok
+  end
+end


### PR DESCRIPTION
## Example WebSocket client

```js
export class AlgoraSocket {
  constructor(channel) {
    this.url = `ws://tv.algora.io/chat/${channel}/websocket`;
    this.scheduleHeartBeat();
  }

  connect() {
    this.hasErrored = false;
    this.socket = new WebSocket(this.url);
    let that = this;
    this.socket.onclose = () => {
      that.onClose();
    };
    this.socket.onerror = (errorEvent) => {
      that.onError(errorEvent);
    };
    this.socket.onmessage = (messageEvent) => {
      that.onMessage(messageEvent);
    };
    this.attemptReopen = true;
  }

  close() {
    this.attemptReopen = false;
    if (this.socket) this.socket.close();
    this.socket = null;
    clearTimeout(this.heartBeatId);
  }

  onClose() {
    this.maybeReopen();
  }

  onError(errorEvent) {
    this.hasErrored = true;
  }

  onMessage(messageEvent) {
    console.log("message", JSON.parse(messageEvent.data));
  }

  isSocketClosed() {
    return this.socket == null || this.socket.readyState == 3;
  }

  maybeReopen() {
    let after = this.hasErrored ? 2000 : 0;
    setTimeout(() => {
      if (this.isSocketClosed() && this.attemptReopen) this.connect();
    }, after);
  }

  scheduleHeartBeat() {
    let that = this;
    this.heartBeatId = setTimeout(function () {
      that.sendHeartBeat();
    }, 30000);
  }

  sendHeartBeat() {
    if (this.socket) {
      this.socket.send("💜");
    }
    this.scheduleHeartBeat();
  }
}
```

## Usage

```js
new AlgoraSocket("zaf").connect()
```