### PR TITLE
Terminate interrupted streams

### DIFF
--- a/lib/algora/application.ex
+++ b/lib/algora/application.ex
@@ -55,6 +55,7 @@ defmodule Algora.Application do
         start: {Membrane.RTMP.Source.TcpServer, :start_link, [tcp_server_options]}
       },
       Algora.Stargazer,
+      Algora.Terminate,
       ExMarcel.TableWrapper,
       Algora.Youtube.Chat.Supervisor
       # Start a worker by calling: Algora.Worker.start_link(arg)

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -256,11 +256,11 @@ defmodule Algora.Library do
 
   def terminate_interrupted_streams() do
     from(v in Video,
-          where: v.duration == 0 and v.is_live == false and v.format == :hls and v.corrupted == false,
-          select: v.id
-        )
-        |> Repo.all
-        |> Enum.each(&terminate_stream/1)
+      where: v.duration == 0 and v.is_live == false and v.format == :hls and v.corrupted == false,
+      select: v.id
+    )
+    |> Repo.all()
+    |> Enum.each(&terminate_stream/1)
   end
 
   def toggle_streamer_live(%Video{} = video, is_live) do

--- a/lib/algora/library/video.ex
+++ b/lib/algora/library/video.ex
@@ -17,6 +17,7 @@ defmodule Algora.Library.Video do
     field :description, :string
     field :type, Ecto.Enum, values: [vod: 1, livestream: 2]
     field :format, Ecto.Enum, values: [mp4: 1, hls: 2, youtube: 3]
+    field :corrupted, :boolean, default: false
     field :is_live, :boolean, default: false
     field :thumbnail_url, :string
     field :vertical_thumbnail_url, :string

--- a/lib/algora/terminate.ex
+++ b/lib/algora/terminate.ex
@@ -1,0 +1,34 @@
+defmodule Algora.Terminate do
+  use GenServer
+
+  import Ecto.Query, warn: false
+
+  @terminate_interval :timer.se(10)
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    schedule_terminate()
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:terminate, state) do
+    from(v in Algora.Library.Video,
+          where: v.duration == 0 and v.is_live == false,
+          select: v.id
+        )
+        |> Algora.Repo.Local.all
+        |> Enum.each(&Algora.Library.terminate_stream/1)
+
+    schedule_terminate()
+    {:noreply, state}
+  end
+
+  defp schedule_terminate() do
+    Process.send_after(self(), :terminate, @terminate_interval)
+  end
+end

--- a/lib/algora/terminate.ex
+++ b/lib/algora/terminate.ex
@@ -1,9 +1,7 @@
 defmodule Algora.Terminate do
   use GenServer
 
-  import Ecto.Query, warn: false
-
-  @terminate_interval :timer.se(10)
+  @terminate_interval :timer.hours(1)
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
@@ -17,13 +15,7 @@ defmodule Algora.Terminate do
 
   @impl true
   def handle_info(:terminate, state) do
-    from(v in Algora.Library.Video,
-          where: v.duration == 0 and v.is_live == false,
-          select: v.id
-        )
-        |> Algora.Repo.Local.all
-        |> Enum.each(&Algora.Library.terminate_stream/1)
-
+    Algora.Library.terminate_interrupted_streams()
     schedule_terminate()
     {:noreply, state}
   end

--- a/priv/repo/migrations/20240831185906_add_corrupted_to_video.exs
+++ b/priv/repo/migrations/20240831185906_add_corrupted_to_video.exs
@@ -1,0 +1,9 @@
+defmodule Algora.Repo.Local.Migrations.AddCorruptedToVideo do
+  use Ecto.Migration
+
+  def change do
+    alter table(:videos) do
+      add :corrupted, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
Additions:
- New Algora.Terminate GenServer:
  - Looks for videos with duration 0 and is_live false
  - Calls Algora.Library.terminate_stream with the video id
  - Runs every 10 seconds

- New Algora.Library.terminate_stream/1
  - Gets video manifest
  - Appends "#EXT-X-ENDLIST\n" if necessary
  - Updates video duration
  
 Note:
 With this changes Algora.Terminate should not get the same videos again as the duration is updated.
 Although if the duration is less than a second this could be a problem.
 
 Im learning elixir so any suggestions/changes are appreciated.
 
 /claim #69 