### PR TITLE
Delay toggling live until full segment is ready

### DIFF
--- a/lib/algora/pipeline.ex
+++ b/lib/algora/pipeline.ex
@@ -6,7 +6,8 @@ defmodule Algora.Pipeline do
   alias Algora.{Admin, Library}
   alias Algora.Pipeline.HLS.LLController
 
-  @segment_duration Time.seconds(6)
+  @segment_duration_seconds 6
+  @segment_duration Time.seconds(@segment_duration_seconds)
   @partial_segment_duration Time.milliseconds(200)
 
   @impl true
@@ -94,7 +95,7 @@ defmodule Algora.Pipeline do
   end
 
   def handle_child_notification({:track_playable, :video}, _element, _ctx, state) do
-    Algora.Library.toggle_streamer_live(state.video, true)
+    {:ok, _ref} = :timer.send_after(@segment_duration_seconds * 1000, self(), :go_live)
     {[], state}
   end
 
@@ -164,6 +165,11 @@ defmodule Algora.Pipeline do
       )
     end
 
+    {[], state}
+  end
+
+  def handle_info(:go_live, _ctx, state) do
+    Algora.Library.toggle_streamer_live(state.video, true)
     {[], state}
   end
 


### PR DESCRIPTION
Membrane seems to be sending `track_playable` when the first _part_ is ready, not when the first full segment is ready. This seems to cause Vidstack to stall when the 'just went live' popup is clicked too quickly.

This change simply waits @segment_duration seconds before toggling live. 