### PR TITLE
Capture multiple thumbnails

### DIFF
--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -465,7 +465,7 @@ defmodule Algora.Library do
       }
       |> change()
       |> VideoThumbnail.put_video(video)
-      |> Repo.insert()
+      |> Repo.insert(on_conflict: :nothing)
 
       video
       |> change()
@@ -487,7 +487,7 @@ defmodule Algora.Library do
       }
       |> change()
       |> VideoThumbnail.put_video(video)
-      |> Repo.insert()
+      |> Repo.insert(on_conflict: :nothing)
 
       video
       |> change()

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -8,7 +8,7 @@ defmodule Algora.Library do
   import Ecto.Changeset
   alias Algora.Accounts.User
   alias Algora.{Repo, Accounts, Storage, Cache, ML}
-  alias Algora.Library.{Channel, Video, Events, Subtitle, Segment}
+  alias Algora.Library.{Channel, Video, VideoThumbnail, Events, Subtitle, Segment}
 
   @pubsub Algora.PubSub
 
@@ -459,9 +459,17 @@ defmodule Algora.Library do
            Storage.upload(thumbnail, "#{video.uuid}/#{thumbnail_filename(marker.minutes)}",
              content_type: "image/jpeg"
            ) do
+      {:ok, video_thumbnail} = %VideoThumbnail{
+        thumbnail_url: Video.thumbnail_url(video, thumbnail_filename(marker.minutes)),
+        minutes: marker.minutes
+      }
+      |> change()
+      |> VideoThumbnail.put_video(video)
+      |> Repo.insert()
+
       video
       |> change()
-      |> put_change(:thumbnail_url, Video.thumbnail_url(video, thumbnail_filename(marker.minutes)))
+      |> put_change(:thumbnail_url, video_thumbnail.thumbnail_url)
       |> Repo.update()
     end
   end
@@ -472,9 +480,18 @@ defmodule Algora.Library do
            Storage.upload(thumbnail, "#{video.uuid}/#{thumbnail_filename(marker.minutes)}",
              content_type: "image/jpeg"
            ) do
+
+      {:ok, video_thumbnail} = %VideoThumbnail{
+        thumbnail_url: Video.thumbnail_url(video, thumbnail_filename(marker.minutes)),
+        minutes: marker.minutes
+      }
+      |> change()
+      |> VideoThumbnail.put_video(video)
+      |> Repo.insert()
+
       video
       |> change()
-      |> put_change(:thumbnail_url, Video.thumbnail_url(video, thumbnail_filename(marker.minutes)))
+      |> put_change(:thumbnail_url, video_thumbnail.thumbnail_url)
       |> Repo.update()
     end
   end

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -12,7 +12,9 @@ defmodule Algora.Library do
 
   @pubsub Algora.PubSub
 
-  @thumbnail_filename "index.jpeg"
+  def thumbnail_filename(minutes) do
+    "index-#{minutes}.jpeg"
+  end
 
   def subscribe_to_studio() do
     Phoenix.PubSub.subscribe(@pubsub, topic_studio())
@@ -433,44 +435,46 @@ defmodule Algora.Library do
     Phoenix.PubSub.unsubscribe(@pubsub, topic(channel.user_id))
   end
 
-  defp create_thumbnail_from_file(%Video{} = video, src_path, opts) do
-    dst_path = Path.join(System.tmp_dir!(), "#{video.uuid}.jpeg")
+  defp create_thumbnail_from_file(%Video{} = video, src_path, marker, opts \\ []) do
+    dst_path = Path.join(System.tmp_dir!(), "#{video.uuid}-#{marker.minutes}.jpeg")
 
-    with :ok <- Thumbnex.create_thumbnail(src_path, dst_path, opts) do
-      File.read(dst_path)
+    if not(File.exists?(dst_path)) do
+      :ok = Thumbnex.create_thumbnail(src_path, dst_path, opts)
     end
+
+    File.read(dst_path)
   end
 
-  defp create_thumbnail(%Video{} = video, contents, opts \\ []) do
-    src_path = Path.join(System.tmp_dir!(), "#{video.uuid}.mp4")
+  defp create_thumbnail(%Video{} = video, contents, marker, opts \\ []) do
+    src_path = Path.join(System.tmp_dir!(), "#{video.uuid}-#{marker.minutes}.mp4")
 
     with :ok <- File.write(src_path, contents) do
-      create_thumbnail_from_file(video, src_path, opts)
+      create_thumbnail_from_file(video, src_path, marker, opts)
     end
   end
 
-  def store_thumbnail_from_file(%Video{} = video, src_path, opts \\ []) do
+  def store_thumbnail_from_file(%Video{} = video, src_path, marker \\ %{ minutes: 0 }, opts \\ []) do
     with {:ok, thumbnail} <- create_thumbnail_from_file(video, src_path, opts),
          {:ok, _} <-
-           Storage.upload(thumbnail, "#{video.uuid}/#{@thumbnail_filename}",
+           Storage.upload(thumbnail, "#{video.uuid}/#{thumbnail_filename(marker.minutes)}",
              content_type: "image/jpeg"
            ) do
       video
       |> change()
-      |> put_change(:thumbnail_url, Video.thumbnail_url(video, @thumbnail_filename))
+      |> put_change(:thumbnail_url, Video.thumbnail_url(video, thumbnail_filename(marker.minutes)))
       |> Repo.update()
     end
   end
 
-  def store_thumbnail(%Video{} = video, contents) do
-    with {:ok, thumbnail} <- create_thumbnail(video, contents),
+  def store_thumbnail(%Video{} = video, contents, marker) do
+    with {:ok, thumbnail} <- create_thumbnail(video, contents, marker, time_offset: 0),
          {:ok, _} <-
-           Storage.upload(thumbnail, "#{video.uuid}/#{@thumbnail_filename}",
+           Storage.upload(thumbnail, "#{video.uuid}/#{thumbnail_filename(marker.minutes)}",
              content_type: "image/jpeg"
            ) do
       video
       |> change()
-      |> put_change(:thumbnail_url, Video.thumbnail_url(video, @thumbnail_filename))
+      |> put_change(:thumbnail_url, Video.thumbnail_url(video, thumbnail_filename(marker.minutes)))
       |> Repo.update()
     end
   end
@@ -534,37 +538,39 @@ defmodule Algora.Library do
     :ok
   end
 
-  defp create_og_image_from_file(%Video{} = video, src_path, opts) do
-    dst_path = Path.join(System.tmp_dir!(), "#{video.uuid}-og.png")
+  defp create_og_image_from_file(%Video{} = video, src_path, marker, opts) do
+    dst_path = Path.join(System.tmp_dir!(), "#{video.uuid}-og-#{marker.minutes}.png")
 
-    with :ok <- create_og(src_path, dst_path, opts) do
-      File.read(dst_path)
+    if not(File.exists?(dst_path)) do
+      :ok = create_og(src_path, dst_path, opts)
     end
+
+    File.read(dst_path)
   end
 
-  defp create_og_image(%Video{} = video, opts \\ []) do
-    src_path = Path.join(System.tmp_dir!(), "#{video.uuid}.jpeg")
-    create_og_image_from_file(video, src_path, opts)
+  defp create_og_image(%Video{} = video, marker, opts \\ []) do
+    src_path = Path.join(System.tmp_dir!(), "#{video.uuid}-#{marker.minutes}.jpeg")
+    create_og_image_from_file(video, src_path, marker, opts)
   end
 
-  def store_og_image_from_file(%Video{} = video, src_path, opts \\ []) do
-    with {:ok, og_image} <- create_og_image_from_file(video, src_path, opts),
+  def store_og_image_from_file(%Video{} = video, src_path, marker \\ %{ minutes: 0 }, opts \\ []) do
+    with {:ok, og_image} <- create_og_image_from_file(video, src_path, marker, opts),
          {:ok, _} <-
-           Storage.upload(og_image, "#{video.uuid}/og.png", content_type: "image/png") do
+           Storage.upload(og_image, "#{video.uuid}/og-#{marker.minutes}.png", content_type: "image/png") do
       video
       |> change()
-      |> put_change(:og_image_url, "#{video.url_root}/og.png")
+      |> put_change(:og_image_url, "#{video.url_root}/og-#{marker.minutes}.png")
       |> Repo.update()
     end
   end
 
-  def store_og_image(%Video{} = video) do
-    with {:ok, og_image} <- create_og_image(video),
+  def store_og_image(%Video{} = video, marker) do
+    with {:ok, og_image} <- create_og_image(video, marker, time_offset: 0),
          {:ok, _} <-
-           Storage.upload(og_image, "#{video.uuid}/og.png", content_type: "image/png") do
+           Storage.upload(og_image, "#{video.uuid}/og-#{marker.minutes}.png", content_type: "image/png") do
       video
       |> change()
-      |> put_change(:og_image_url, "#{video.url_root}/og.png")
+      |> put_change(:og_image_url, "#{video.url_root}/og-#{marker.minutes}.png")
       |> Repo.update()
     end
   end

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -467,10 +467,7 @@ defmodule Algora.Library do
       |> VideoThumbnail.put_video(video)
       |> Repo.insert(on_conflict: :nothing)
 
-      video
-      |> change()
-      |> put_change(:thumbnail_url, video_thumbnail.thumbnail_url)
-      |> Repo.update()
+      update_thumbnail_url(video, video_thumbnail)
     end
   end
 
@@ -481,18 +478,13 @@ defmodule Algora.Library do
              content_type: "image/jpeg"
            ) do
 
-      {:ok, video_thumbnail} = %VideoThumbnail{
+      %VideoThumbnail{
         thumbnail_url: Video.thumbnail_url(video, thumbnail_filename(marker.minutes)),
         minutes: marker.minutes
       }
       |> change()
       |> VideoThumbnail.put_video(video)
       |> Repo.insert(on_conflict: :nothing)
-
-      video
-      |> change()
-      |> put_change(:thumbnail_url, video_thumbnail.thumbnail_url)
-      |> Repo.update()
     end
   end
 
@@ -590,6 +582,13 @@ defmodule Algora.Library do
       |> put_change(:og_image_url, "#{video.url_root}/og-#{marker.minutes}.png")
       |> Repo.update()
     end
+  end
+
+  def update_thumbnail_url(%Video{} = video, %VideoThumbnail{} = video_thumbnail) do
+    video
+    |> change()
+    |> put_change(:thumbnail_url, video_thumbnail.thumbnail_url)
+    |> Repo.update()
   end
 
   def get_thumbnail_url(%Video{} = video) do

--- a/lib/algora/library/video_thumbnail.ex
+++ b/lib/algora/library/video_thumbnail.ex
@@ -1,0 +1,20 @@
+defmodule Algora.Library.VideoThumbnail do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query
+
+  alias Algora.Library.Video
+
+  schema "video_thumbnails" do
+    field :minutes, :integer
+    field :thumbnail_url, :string
+
+    belongs_to :video, Video
+
+    timestamps()
+  end
+
+  def put_video(%Ecto.Changeset{} = changeset, %Video{} = video) do
+    put_assoc(changeset, :video, video)
+  end
+end

--- a/lib/algora/pipeline/storage.ex
+++ b/lib/algora/pipeline/storage.ex
@@ -259,7 +259,7 @@ defmodule Algora.Pipeline.Storage do
       end)
     end
 
-    %{state | setup_completed?: false, video_segment: contents}
+    %{state | setup_completed?: if(marker, do: Thumbnails.is_last_marker?(marker), else: false), video_segment: contents}
   end
 
   defp process_contents(

--- a/lib/algora/pipeline/storage/thumbnails.ex
+++ b/lib/algora/pipeline/storage/thumbnails.ex
@@ -1,0 +1,38 @@
+defmodule Algora.Pipeline.Storage.Thumbnails do
+  @moduledoc false
+
+  require Membrane.Logger
+  alias Algora.Library
+
+  @thumbnail_intervals [0, 1, 2, 4, 8, 16]
+  @segments_per_minute 30
+
+  @pubsub Algora.PubSub
+
+  def store_thumbnail(video, video_header, contents) do
+    with {:ok, video} <- Library.store_thumbnail(video, video_header <> contents),
+         {:ok, video} <- Library.store_og_image(video) do
+      broadcast_thumbnails_generated!(video)
+    else
+      _ ->
+        Membrane.Logger.error("Could not generate thumbnails for video #{video.id}")
+    end
+  end
+
+  def thumbnail_interval_segments() do
+    @thumbnail_intervals
+      |> Enum.map(& &1 * @segments_per_minute)
+  end
+
+  defp broadcast_thumbnails_generated!(video) do
+    # HACK: this shouldn't be necessary
+    # atm we need it because initially the video does not have the user field set
+    video = Library.get_video!(video.id)
+
+    Phoenix.PubSub.broadcast!(
+      @pubsub,
+      Library.topic_livestreams(),
+      {__MODULE__, %Library.Events.ThumbnailsGenerated{video: video}}
+    )
+  end
+end

--- a/lib/algora/pipeline/storage/thumbnails.ex
+++ b/lib/algora/pipeline/storage/thumbnails.ex
@@ -31,6 +31,10 @@ defmodule Algora.Pipeline.Storage.Thumbnails do
     end)
   end
 
+  def is_last_marker?(marker) do
+    List.last(@thumbnail_markers) == marker
+  end
+
   defp broadcast_thumbnails_generated!(video) do
     # HACK: this shouldn't be necessary
     # atm we need it because initially the video does not have the user field set

--- a/priv/repo/migrations/20240926215228_add_video_thumbnails_table.exs
+++ b/priv/repo/migrations/20240926215228_add_video_thumbnails_table.exs
@@ -1,0 +1,15 @@
+defmodule Algora.Repo.Local.Migrations.AddVideoThumbnailsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:video_thumbnails) do
+      add :minutes, :integer, null: false
+      add :thumbnail_url, :string, null: false
+      add :video_id, references(:videos, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:video_thumbnails, [:video_id])
+  end
+end

--- a/priv/repo/migrations/20240926215228_add_video_thumbnails_table.exs
+++ b/priv/repo/migrations/20240926215228_add_video_thumbnails_table.exs
@@ -11,5 +11,6 @@ defmodule Algora.Repo.Local.Migrations.AddVideoThumbnailsTable do
     end
 
     create index(:video_thumbnails, [:video_id])
+    create index(:video_thumbnails, [:video_id, :minutes], unique: true)
   end
 end


### PR DESCRIPTION
Part 1/2 of #81

Posting this for feedback before I implement the UI part.

From my perspective this could be merged before that part is completed (I could claim bounty in the second PR).

> I think we should use exponential backoff (e.g. on minute 0, 1, 2, 4, 8, 16) so that we get a few options from the get-go and a few more later for variety.

Capturing these thumbnails has been implemented based on the segment number. This roughly maps to the minute but is not exact.

I've tested this by streaming a webview of a [Count Up timer](https://www.timeme.com/timer.htm?17ps09kfzv50660501/Count+Up+Timer). I did vary the framerate and bitrate which didn't seem to affect the segment numbers... but I'm not an expert in Membrane streams.

Example thumbnails:
![ebf7f8fc-8b72-4e00-880d-98e30fa55eb0-0](https://github.com/user-attachments/assets/bf6815b1-d6ad-4774-808f-b4445b51fe6a)
![ebf7f8fc-8b72-4e00-880d-98e30fa55eb0-1](https://github.com/user-attachments/assets/05f321ec-be75-4ca6-8bc8-3935aa8fab0e)
![ebf7f8fc-8b72-4e00-880d-98e30fa55eb0-2](https://github.com/user-attachments/assets/0a114d69-cda9-4870-aed9-dad7295bdb0a)

And equivalent OG images:

![image](https://github.com/user-attachments/assets/e054dc32-f1eb-42a2-8bd8-81c8bfea76b9)
![image](https://github.com/user-attachments/assets/6548f74a-26be-47ff-84d4-fd60fc351d8e)
![image](https://github.com/user-attachments/assets/c3a4875a-ccf0-4409-8454-e2a5b7ad5c66)

In tigris storage:
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/921e9314-e63a-406f-9b4b-ac101b257868">

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/3a0a885a-9094-4277-8210-a2b91dc3cd51">

In Algora TV UI:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/4405aeae-2f56-4543-bb93-00254f3107a7">


As the thumbnail and OG images are captured, they are stored in the `video_thumbnails` table as well as being updated on the `Video` record, this provides a more up-to-date preview automatically.