### PR TITLE
fix: return to original page after login (#101)

### DIFF
--- a/lib/algora_web/controllers/oauth_login_controller.ex
+++ b/lib/algora_web/controllers/oauth_login_controller.ex
@@ -1,6 +1,7 @@
 defmodule AlgoraWeb.OAuthLoginController do
   use AlgoraWeb, :controller
   require Logger
+  import AlgoraWeb.UserAuth, only: [maybe_store_return_to: 1]
 
   def new(conn, %{"provider" => "restream"} = params) do
     if conn.assigns.current_user do
@@ -11,7 +12,9 @@ defmodule AlgoraWeb.OAuthLoginController do
       |> put_session(:restream_state, state)
       |> redirect(external: Algora.Restream.authorize_url(state))
     else
-      conn |> redirect(to: ~p"/auth/login")
+      conn 
+      |> maybe_store_return_to()
+      |> redirect(to: ~p"/auth/login")
     end
   end
 end

--- a/lib/algora_web/controllers/redirect_controller.ex
+++ b/lib/algora_web/controllers/redirect_controller.ex
@@ -1,7 +1,7 @@
 defmodule AlgoraWeb.RedirectController do
   use AlgoraWeb, :controller
 
-  import AlgoraWeb.UserAuth, only: [fetch_current_user: 2]
+  import AlgoraWeb.UserAuth, only: [fetch_current_user: 2, maybe_store_return_to: 1]
 
   plug :fetch_current_user
 
@@ -9,7 +9,9 @@ defmodule AlgoraWeb.RedirectController do
     if conn.assigns.current_user do
       AlgoraWeb.UserAuth.redirect_if_user_is_authenticated(conn, [])
     else
-      redirect(conn, to: ~p"/auth/login")
+      conn
+      |> maybe_store_return_to()
+      |> redirect(to: ~p"/auth/login")
     end
   end
 end

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -54,8 +54,12 @@ defmodule AlgoraWeb.UserAuth do
   end
 
   defp redirect_require_login(socket) do
-    socket
+
+  conn = Phoenix.LiveView.get_connect_info(socket).conn 
+  
+    conn
     |> LiveView.put_flash(:error, "Please sign in")
+    |> maybe_store_return_to()
     |> LiveView.redirect(to: ~p"/auth/login")
   end
 
@@ -157,13 +161,13 @@ defmodule AlgoraWeb.UserAuth do
     end
   end
 
-  defp maybe_store_return_to(%{method: "GET"} = conn) do
+  def maybe_store_return_to(%{method: "GET"} = conn) do
     %{request_path: request_path, query_string: query_string} = conn
     return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
     put_session(conn, :user_return_to, return_to)
   end
 
-  defp maybe_store_return_to(conn), do: conn
+  def maybe_store_return_to(conn), do: conn
 
   def signed_in_path(_conn), do: "/"
 end

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -54,14 +54,14 @@ defmodule AlgoraWeb.UserAuth do
   end
 
   defp redirect_require_login(socket) do
-
-  conn = Phoenix.LiveView.get_connect_info(socket).conn 
   
-    conn
-    |> LiveView.put_flash(:error, "Please sign in")
-    |> maybe_store_return_to()
-    |> LiveView.redirect(to: ~p"/auth/login")
-  end
+  conn = Phoenix.LiveView.get_connect_info(socket).conn
+
+  conn
+  |> maybe_store_return_to()  # Store the return path before flashing the message
+  |> LiveView.put_flash(:error, "Please sign in")
+  |> LiveView.redirect(to: ~p"/auth/login")
+end
 
   @doc """
   Logs the user in.

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -58,7 +58,7 @@ defmodule AlgoraWeb.UserAuth do
   %{request_path: request_path, query_string: query_string} = conn
 
   return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
-  socket = put_session(socket, :user_return_to, return_to)
+  socket = LiveView.put_session(socket, :user_return_to, return_to)
 
   socket
   |> LiveView.put_flash(:error, "Please sign in")

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -54,10 +54,13 @@ defmodule AlgoraWeb.UserAuth do
   end
 
   defp redirect_require_login(socket) do
+  conn = Phoenix.LiveView.get_connect_info(socket)[:conn]
+  %{request_path: request_path, query_string: query_string} = conn
   
-  case LiveView.get_connect_info(socket).conn
-    %{conn: conn} ->
-      conn
+  return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
+  socket = Phoenix.LiveView.put_session(socket, :user_return_to, return_to)
+
+  socket
   |> maybe_store_return_to()
   |> LiveView.put_flash(:error, "Please sign in")
   |> LiveView.redirect(to: ~p"/auth/login")

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -58,11 +58,10 @@ defmodule AlgoraWeb.UserAuth do
   %{request_path: request_path, query_string: query_string} = conn
 
   return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
-  socket = LiveView.put_session(socket, :user_return_to, return_to)
 
   socket
   |> LiveView.put_flash(:error, "Please sign in")
-  |> LiveView.redirect(to: ~p"/auth/login")
+  |> LiveView.redirect(to: ~p"/auth/login?return_to=#{URI.encode_www_form(return_to)}")
 end
 
   @doc """

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -56,12 +56,11 @@ defmodule AlgoraWeb.UserAuth do
   defp redirect_require_login(socket) do
   conn = Phoenix.LiveView.get_connect_info(socket)[:conn]
   %{request_path: request_path, query_string: query_string} = conn
-  
+
   return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
   socket = Phoenix.LiveView.put_session(socket, :user_return_to, return_to)
 
   socket
-  |> maybe_store_return_to()
   |> LiveView.put_flash(:error, "Please sign in")
   |> LiveView.redirect(to: ~p"/auth/login")
 end

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -55,10 +55,10 @@ defmodule AlgoraWeb.UserAuth do
 
   defp redirect_require_login(socket) do
   
-  conn = Phoenix.LiveView.get_connect_info(socket).conn
-
-  conn
-  |> maybe_store_return_to()  # Store the return path before flashing the message
+  case LiveView.get_connect_info(socket).conn
+    %{conn: conn} ->
+      conn
+  |> maybe_store_return_to()
   |> LiveView.put_flash(:error, "Please sign in")
   |> LiveView.redirect(to: ~p"/auth/login")
 end

--- a/lib/algora_web/controllers/user_auth.ex
+++ b/lib/algora_web/controllers/user_auth.ex
@@ -54,11 +54,11 @@ defmodule AlgoraWeb.UserAuth do
   end
 
   defp redirect_require_login(socket) do
-  conn = Phoenix.LiveView.get_connect_info(socket)[:conn]
+  conn = LiveView.get_connect_info(socket, :conn)
   %{request_path: request_path, query_string: query_string} = conn
 
   return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
-  socket = Phoenix.LiveView.put_session(socket, :user_return_to, return_to)
+  socket = put_session(socket, :user_return_to, return_to)
 
   socket
   |> LiveView.put_flash(:error, "Please sign in")

--- a/lib/algora_web/live/show_live/show.ex
+++ b/lib/algora_web/live/show_live/show.ex
@@ -1,5 +1,6 @@
 defmodule AlgoraWeb.ShowLive.Show do
   use AlgoraWeb, :live_view
+  import AlgoraWeb.UserAuth, only: [maybe_store_return_to: 1]
 
   alias Algora.{Shows, Library, Events}
   alias Algora.Accounts
@@ -344,9 +345,12 @@ defmodule AlgoraWeb.ShowLive.Show do
 
     show = Shows.get_show_by_fields!(slug: slug)
 
+    conn = Phoenix.LiveView.get_connect_info(socket).conn
+
     cond do
       current_user == nil ->
-        socket
+        conn
+        |> maybe_store_return_to()
         |> redirect(to: ~p"/auth/login")
 
       current_user.id != show.user_id && !Accounts.admin?(current_user) ->

--- a/lib/algora_web/live/show_live/show.ex
+++ b/lib/algora_web/live/show_live/show.ex
@@ -345,7 +345,7 @@ defmodule AlgoraWeb.ShowLive.Show do
 
     show = Shows.get_show_by_fields!(slug: slug)
 
-    conn = Phoenix.LiveView.get_connect_info(socket).conn
+    conn = get_connect_info(socket, :conn)
 
     cond do
       current_user == nil ->


### PR DESCRIPTION
# Fix Redirect to Original Page After Login (#101)

### PR Description:
Ensures users are redirected to their intended page after login by consistently setting the `:user_return_to` session value.

#### Problem:
Users are redirected to the homepage after login if the `:user_return_to` session is not set.

#### Solution:
Updated login flow to always set `:user_return_to` when redirecting to the login page.

Closes #101 
/claim #101