### PR TITLE
perf(clipper): download segments instead of full video

### DIFF
--- a/lib/algora/clipper.ex
+++ b/lib/algora/clipper.ex
@@ -60,7 +60,7 @@ defmodule Algora.Clipper do
     %{playlist: %{playlists.video | timeline: timeline}, ss: ss}
   end
 
-  def clip_manifest(video, from, to) do
+  def trim_manifest(video, from, to) do
     uuid = Ecto.UUID.generate()
 
     %{playlist: playlist, ss: ss} = clip(video, from, to)
@@ -85,7 +85,7 @@ defmodule Algora.Clipper do
   end
 
   def create_clip(video, from, to) do
-    %{url: url, ss: ss} = clip_manifest(video, from, to)
+    %{url: url, ss: ss} = trim_manifest(video, from, to)
     filename = Slug.slugify("#{video.title}-#{Library.to_hhmmss(from)}-#{Library.to_hhmmss(to)}")
 
     "ffmpeg -i \"#{url}\" -ss #{ss} -t #{to - from} \"#{filename}.mp4\""
@@ -105,7 +105,7 @@ defmodule Algora.Clipper do
         to = Library.from_hhmmss(clip["clip_to"])
 
         # Get trimmed manifest for this clip
-        %{url: url, ss: ss} = clip_manifest(video, from, to)
+        %{url: url, ss: ss} = trim_manifest(video, from, to)
         temp_path = Path.join(System.tmp_dir(), "#{filename}_part#{System.unique_integer()}.mp4")
 
         # Download this clip segment
@@ -117,8 +117,6 @@ defmodule Algora.Clipper do
           "#{ss}",
           "-t",
           "#{to - from}",
-          "-c",
-          "copy",
           temp_path
         ]
 

--- a/lib/algora/clipper.ex
+++ b/lib/algora/clipper.ex
@@ -182,32 +182,4 @@ defmodule Algora.Clipper do
 
     Slug.slugify("#{video.title}-#{clip_count}clips-#{total_duration}s")
   end
-
-  defp create_filter_complex(clips_params) do
-    {filter_complex, _} =
-      clips_params
-      |> Enum.sort_by(fn {key, _} -> key end)
-      |> Enum.reduce({"", 0}, fn {_, clip}, {acc, index} ->
-        from = Library.from_hhmmss(clip["clip_from"])
-        to = Library.from_hhmmss(clip["clip_to"])
-
-        clip_filter =
-          "[0:v]trim=start=#{from}:end=#{to},setpts=PTS-STARTPTS[v#{index}]; " <>
-            "[0:a]atrim=start=#{from}:end=#{to},asetpts=PTS-STARTPTS[a#{index}];\n"
-
-        {acc <> clip_filter, index + 1}
-      end)
-
-    clip_count = map_size(clips_params)
-
-    video_concat =
-      Enum.map_join(0..(clip_count - 1), "", fn i -> "[v#{i}]" end) <>
-        "concat=n=#{clip_count}:v=1:a=0[v];\n"
-
-    audio_concat =
-      Enum.map_join(0..(clip_count - 1), "", fn i -> "[a#{i}]" end) <>
-        "concat=n=#{clip_count}:v=0:a=1[a]"
-
-    filter_complex <> video_concat <> audio_concat
-  end
 end

--- a/lib/algora/clipper.ex
+++ b/lib/algora/clipper.ex
@@ -113,6 +113,7 @@ defmodule Algora.Clipper do
           "-y",
           "-i",
           url,
+          # TODO: Use -ss in input position, see https://superuser.com/a/1845442
           "-ss",
           "#{ss}",
           "-t",

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -169,7 +169,13 @@ defmodule Algora.Library do
     |> Enum.each(fn hls_local_path ->
       Storage.upload_from_filename(
         hls_local_path,
-        "#{hls_uuid}/#{Path.basename(hls_local_path)}"
+        "#{hls_uuid}/#{Path.basename(hls_local_path)}",
+        cb,
+        content_type:
+          if(String.ends_with?(hls_local_path, ".m3u8"),
+            do: "application/x-mpegURL",
+            else: "video/mp4"
+          )
       )
     end)
 

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -136,7 +136,6 @@ defmodule Algora.Library do
 
     dir = Path.join(Admin.tmp_dir(), hls_uuid)
     File.mkdir_p!(dir)
-    hls_local_path = Path.join(dir, hls_filename)
 
     cb.(%{stage: :transmuxing, done: 1, total: 1})
 
@@ -145,6 +144,8 @@ defmodule Algora.Library do
       video.local_path,
       "-c",
       "copy",
+      "-master_pl_name",
+      hls_filename,
       "-start_number",
       "0",
       "-hls_time",
@@ -153,7 +154,9 @@ defmodule Algora.Library do
       "0",
       "-f",
       "hls",
-      hls_local_path
+      "-hls_segment_filename",
+      "#{dir}/muxed_segment_%d_g3cFdmlkZW8.ts",
+      "#{dir}/g3cFdmlkZW8.m3u8"
     ])
 
     files = Path.wildcard("#{dir}/*")


### PR DESCRIPTION
Currently ffmpeg downloads the entire video stream before processing the clips, which can be very slow

This change downloads only the needed segments for each clip using trimmed HLS manifests and then concatenates them using the concat demuxer