### PR TITLE
Hide unlisted videos from channel

### DIFF
--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -783,7 +783,8 @@ defmodule Algora.Library do
       where:
         not is_nil(v.url) and
           is_nil(v.transmuxed_from_id) and
-          v.user_id == ^channel.user_id
+          v.user_id == ^channel.user_id and
+          v.visibility == :public
     )
     |> Video.not_deleted()
     |> order_by_live()


### PR DESCRIPTION
## Fix: Hide unlisted videos from channel (#20 and #27)
### PR Description:
Unlisted videos no longer show up in channel video list.

### Problem:
Unlisted videos are hidden from the front page, but still show up in channel page.

### Solution:
Add filter to list function to only show videos that have visibility set to public.