### PR TITLE
Upload LL-HLS Partials to Object Storage

### DIFF
--- a/lib/algora/pipeline.ex
+++ b/lib/algora/pipeline.ex
@@ -10,7 +10,7 @@ defmodule Algora.Pipeline do
 
   @segment_duration_seconds 6
   @segment_duration Time.seconds(@segment_duration_seconds)
-  @partial_segment_duration_milliseconds 200
+  @partial_segment_duration_milliseconds 1000
   @partial_segment_duration Time.milliseconds(@partial_segment_duration_milliseconds)
   @app "live"
   @terminate_after String.to_integer(Algora.config([:resume_rtmp_timeout])) * 1000

--- a/lib/algora/pipeline/hls/ets_helper.ex
+++ b/lib/algora/pipeline/hls/ets_helper.ex
@@ -154,9 +154,15 @@ defmodule Algora.Pipeline.HLS.EtsHelper do
   end
 
   defp lookup_helper(table, key, error) do
-    case :ets.lookup(table, key) do
-      [{^key, val}] -> {:ok, val}
-      [] -> {:error, error}
+    try do
+      case :ets.lookup(table, key) do
+        [{^key, val}] -> {:ok, val}
+        [] -> {:error, error}
+      end
+    rescue
+      error in ArgumentError ->
+        # table not found
+        {:error, error}
     end
   end
 

--- a/lib/algora/pipeline/sink.ex
+++ b/lib/algora/pipeline/sink.ex
@@ -344,6 +344,11 @@ defmodule Algora.Pipeline.Sink do
     end
   end
 
+  @impl true
+  def handle_info({:DOWN, _rev, :process, _pid, _reason}, _ctx, state) do
+    {[], state}
+  end
+
   defp serialize_track_name(track_id) when is_binary(track_id) do
     valid_filename_regex = ~r/^[^\/:*?"<>|]+$/
 

--- a/lib/algora/storage.ex
+++ b/lib/algora/storage.ex
@@ -69,4 +69,14 @@ defmodule Algora.Storage do
       err -> err
     end
   end
+
+  def remove(remote_path, opts \\ []) do
+    remove_from_bucket(remote_path, :media, opts)
+  end
+
+  def remove_from_bucket(remote_path, bucket, opts) do
+    ExAws.S3.delete_object(Algora.config([:buckets, bucket]), remote_path, opts)
+    |> ExAws.request([])
+  end
+
 end

--- a/lib/algora_web/controllers/hls_content_controller.ex
+++ b/lib/algora_web/controllers/hls_content_controller.ex
@@ -98,6 +98,10 @@ defmodule AlgoraWeb.HLSContentController do
 
         Conn.send_resp(conn, 200, file)
 
+      {:redirect, partial_name} ->
+        redirect(conn,
+          external: Algora.Storage.to_absolute(:video, video_uuid, partial_name))
+
       {:error, :invalid_path} ->
         {:error, :bad_request, "Invalid filename, got #{filename}"}
 


### PR DESCRIPTION
This PR makes it so requests for partial segments are served from S3/Tigris instead of being served from the application servers.