### PR TITLE
Tune pipeline to better handle reconnects

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -252,22 +252,6 @@ const Hooks = {
               startLevel: -1,
               testBandwidth: !opts.is_live,
               lowLatencyMode: opts.is_live,
-              playlistLoadPolicy: {
-                default: {
-                  maxTimeToFirstByteMs: 2000,
-                  maxLoadTimeMs: 3000,
-                  timeoutRetry: {
-                    maxNumRetry: 100,
-                    retryDelayMs: 200,
-                    maxRetryDelayMs: 1000,
-                  },
-                  errorRetry: {
-                    maxNumRetry: 100,
-                    retryDelayMs: 200,
-                    maxRetryDelayMs: 1000,
-                  },
-                },
-              },
             };
           }
         });

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -248,16 +248,26 @@ const Hooks = {
           if (isHLSProvider(provider)) {
             provider.library = HLS;
             provider.config = {
-              targetlatency: 6, // one segment
-              capLevelToPlayerSize: true,
-              capLevelOnFPSDrop: false,
               startFragPrefetch: !opts.is_live,
               startLevel: -1,
               testBandwidth: !opts.is_live,
               lowLatencyMode: opts.is_live,
-              maxFragLookUpTolerance: 60 * 60, // 60 minutes
-              maxBufferHole: 0.001,
-              highBufferWatchdogPeriod: 0.01,
+              playlistLoadPolicy: {
+                default: {
+                  maxTimeToFirstByteMs: 2000,
+                  maxLoadTimeMs: 3000,
+                  timeoutRetry: {
+                    maxNumRetry: 100,
+                    retryDelayMs: 200,
+                    maxRetryDelayMs: 1000,
+                  },
+                  errorRetry: {
+                    maxNumRetry: 100,
+                    retryDelayMs: 200,
+                    maxRetryDelayMs: 1000,
+                  },
+                },
+              },
             };
           }
         });

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,7 +20,7 @@
     "@types/phoenix_live_view": "^0.18.4"
   },
   "dependencies": {
-    "@algora/hls.js": "1.0.0",
+    "@algora/hls.js": "1.5.17-algora.1",
     "vidstack": "^1.12.9"
   }
 }

--- a/assets/pnpm-lock.yaml
+++ b/assets/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@algora/hls.js':
-    specifier: 1.0.0
-    version: 1.0.0
+    specifier: 1.5.17-algora.1
+    version: 1.5.17-algora.1
   vidstack:
     specifier: ^1.12.9
     version: 1.12.9
@@ -22,8 +22,8 @@ devDependencies:
 
 packages:
 
-  /@algora/hls.js@1.0.0:
-    resolution: {integrity: sha512-2Lh/sBnxeyD4gi2F8Isr5CsliQQ6t5Nf0+I9jLkibLmHkryVMis+z0PssPA5iOGZncvSgAwhAlDf2wxwJtsRcw==}
+  /@algora/hls.js@1.5.17-algora.1:
+    resolution: {integrity: sha512-VarvdusHFzZefiiL7wu9lN9YNRFlGpoZdWC83K4bY7rqz+mXER++FTfnsM3IIHWJ9ZZjQtebAZP2rvp4mnB8vw==}
     dev: false
 
   /@floating-ui/core@1.6.7:

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -353,7 +353,7 @@ defmodule Algora.Library do
 
     msg =
       if is_live do
-        %Events.LivestreamStarted{video: video, resume: status == :resume}
+        %Events.LivestreamStarted{video: video, resume: status == :resumed}
       else
         %Events.LivestreamEnded{video: video, resume: status == :paused}
       end

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -301,10 +301,13 @@ defmodule Algora.Library do
     |> Enum.each(&terminate_stream/1)
   end
 
-  @type stream_status :: :live | :paused | :stopped
+  @type stream_status :: :live | :paused | :resumed | :stopped
 
   @spec maybe_update_duration(Ecto.Changeset.t(), stream_status) :: Ecto.Changeset.t()
   defp maybe_update_duration(changeset, :live), do: changeset |> put_change(:duration, 0)
+
+  defp maybe_update_duration(changeset, status)
+    when status in [:paused, :resumed], do: changeset
 
   defp maybe_update_duration(changeset, _) do
     with {:ok, duration} <- get_duration(changeset.data),
@@ -325,18 +328,20 @@ defmodule Algora.Library do
     video = get_video!(video.id)
     user = Accounts.get_user!(video.user_id)
 
-    is_live = status == :live
+    is_live = status == :live or status == :resumed
 
     Repo.update_all(from(u in Accounts.User, where: u.id == ^video.user_id),
       set: [is_live: is_live]
     )
 
-    Repo.update_all(
-      from(v in Video,
-        where: v.user_id == ^video.user_id and (v.id != ^video.id or not (^is_live))
-      ),
-      set: [is_live: false]
-    )
+    if status != :resumed do
+      Repo.update_all(
+        from(v in Video,
+          where: v.user_id == ^video.user_id and (v.id != ^video.id or not (^is_live))
+        ),
+        set: [is_live: false]
+      )
+    end
 
     video = get_video!(video.id)
 
@@ -349,12 +354,13 @@ defmodule Algora.Library do
     end
 
     msg =
-      case is_live do
-        true -> %Events.LivestreamStarted{video: video}
-        false -> %Events.LivestreamEnded{video: video}
+      case status do
+        :live -> %Events.LivestreamStarted{video: video}
+        :stopped -> %Events.LivestreamEnded{video: video}
+        _status -> nil
       end
 
-    broadcast!(topic_livestreams(), msg)
+    if msg, do: broadcast!(topic_livestreams(), msg)
 
     sink_url = Algora.config([:event_sink, :url])
 

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -358,7 +358,7 @@ defmodule Algora.Library do
         %Events.LivestreamEnded{video: video, resume: status == :paused}
       end
 
-    if msg, do: broadcast!(topic_livestreams(), msg)
+    broadcast!(topic_livestreams(), msg)
 
     sink_url = Algora.config([:event_sink, :url])
 

--- a/lib/algora/library/events.ex
+++ b/lib/algora/library/events.ex
@@ -1,10 +1,10 @@
 defmodule Algora.Library.Events do
   defmodule LivestreamStarted do
-    defstruct video: nil
+    defstruct video: nil, resume: false
   end
 
   defmodule LivestreamEnded do
-    defstruct video: nil
+    defstruct video: nil, resume: false
   end
 
   defmodule ThumbnailsGenerated do

--- a/lib/algora/pipeline.ex
+++ b/lib/algora/pipeline.ex
@@ -185,7 +185,7 @@ defmodule Algora.Pipeline do
 
     send(self(), :link_tracks)
     setup_forwarding!(state)
-    Algora.Library.toggle_stream_status(state.video, :live)
+    Algora.Library.toggle_stream_status(state.video, :resumed)
 
     spec = {actions, clock_provider: {:src, reconnect}, group: :rtmp_input, crash_group_mode: :temporary}
 

--- a/lib/algora/pipeline.ex
+++ b/lib/algora/pipeline.ex
@@ -458,7 +458,7 @@ defmodule Algora.Pipeline do
     )
   end
 
-  defp setup_forwarding!(%{video: video} = state) do
+  defp setup_forwarding!(%{video: video}) do
     destinations = Algora.Accounts.list_active_destinations(video.user_id)
 
     for destination <- destinations do
@@ -471,7 +471,7 @@ defmodule Algora.Pipeline do
     end
   end
 
-  defp setup_extras!(%{video: video, user: user} = state) do
+  defp setup_extras!(%{video: video, user: user}) do
     if url = Algora.Accounts.get_restream_ws_url(user) do
       Task.Supervisor.start_child(
         Algora.TaskSupervisor,

--- a/lib/algora/pipeline/hls.ex
+++ b/lib/algora/pipeline/hls.ex
@@ -24,7 +24,7 @@ defmodule Algora.Pipeline.HLS do
   @default_audio_track_id "audio_default_id"
   @default_audio_track_name "audio_default_name"
 
-  @keep_latest_n_segment_parts 24
+  @keep_latest_n_segment_parts 4
   @min_segments_in_delta_playlist 4
 
   defmodule SegmentAttribute do

--- a/lib/algora/pipeline/hls.ex
+++ b/lib/algora/pipeline/hls.ex
@@ -24,8 +24,8 @@ defmodule Algora.Pipeline.HLS do
   @default_audio_track_id "audio_default_id"
   @default_audio_track_name "audio_default_name"
 
-  @keep_latest_n_segment_parts 4
-  @min_segments_in_delta_playlist 6
+  @keep_latest_n_segment_parts 24
+  @min_segments_in_delta_playlist 4
 
   defmodule SegmentAttribute do
     @moduledoc """

--- a/lib/algora/pipeline/hls.ex
+++ b/lib/algora/pipeline/hls.ex
@@ -25,7 +25,7 @@ defmodule Algora.Pipeline.HLS do
   @default_audio_track_name "audio_default_name"
 
   @keep_latest_n_segment_parts 4
-  @min_segments_in_delta_playlist 6
+  @min_segments_in_delta_playlist @keep_latest_n_segment_parts - 1
 
   defmodule SegmentAttribute do
     @moduledoc """

--- a/lib/algora/pipeline/hls.ex
+++ b/lib/algora/pipeline/hls.ex
@@ -25,7 +25,7 @@ defmodule Algora.Pipeline.HLS do
   @default_audio_track_name "audio_default_name"
 
   @keep_latest_n_segment_parts 4
-  @min_segments_in_delta_playlist 4
+  @min_segments_in_delta_playlist 6
 
   defmodule SegmentAttribute do
     @moduledoc """

--- a/lib/algora/pipeline/source_bin.ex
+++ b/lib/algora/pipeline/source_bin.ex
@@ -15,6 +15,8 @@ defmodule Algora.Pipeline.SourceBin do
 
   alias Membrane.{AAC, H264, RTMP}
 
+  def_clock "rtmp clock"
+
   def_output_pad :video,
     accepted_format: H264,
     availability: :on_request

--- a/lib/algora/pipeline/storage.ex
+++ b/lib/algora/pipeline/storage.ex
@@ -38,9 +38,8 @@ defmodule Algora.Pipeline.Storage do
           partial_uploaders: %{ manifest_name() => pid() }
         }
 
-  @ets_cached_duration_in_segments 4
+  @ets_cached_duration_in_segments 24
   @delta_manifest_suffix "_delta.m3u8"
-  @partial_uploader_send_update_timeout 1000
 
   @impl true
   def init(state) do

--- a/lib/algora_web/live/channel_live.ex
+++ b/lib/algora_web/live/channel_live.ex
@@ -293,6 +293,21 @@ defmodule AlgoraWeb.ChannelLive do
   end
 
   def handle_info(
+        {Library, %Library.Events.LivestreamStarted{video: video, resume: true}},
+        socket
+      ) do
+    %{channel: channel} = socket.assigns
+
+    {:noreply,
+     if video.user_id == channel.user_id do
+       socket
+       |> assign(channel: %{channel | is_live: false})
+     else
+       socket
+     end}
+  end
+
+  def handle_info(
         {Library, %Library.Events.LivestreamEnded{video: video}},
         socket
       ) do

--- a/lib/algora_web/live/embed_live.ex
+++ b/lib/algora_web/live/embed_live.ex
@@ -99,7 +99,7 @@ defmodule AlgoraWeb.EmbedLive do
   end
 
   def handle_info(
-        {Library, %Library.Events.LivestreamStarted{video: video}},
+        {Library, %Library.Events.LivestreamStarted{video: video, resume: false}},
         socket
       ) do
     %{channel: channel} = socket.assigns
@@ -115,7 +115,7 @@ defmodule AlgoraWeb.EmbedLive do
   end
 
   def handle_info(
-        {Library, %Library.Events.LivestreamEnded{video: video}},
+        {Library, %Library.Events.LivestreamEnded{video: video, resume: false}},
         socket
       ) do
     %{channel: channel} = socket.assigns

--- a/lib/algora_web/live/video_live.ex
+++ b/lib/algora_web/live/video_live.ex
@@ -704,12 +704,26 @@ defmodule AlgoraWeb.VideoLive do
         socket
       ) do
     {:noreply,
-     if video.user_id == socket.assigns.channel.user_id do
+     socket = if video.user_id == socket.assigns.channel.user_id do
        socket
        |> stream_insert(:videos, video, at: 0)
      else
        socket
      end}
+  end
+
+  def handle_info(
+        {Library, %Library.Events.LivestreamStarted{video: video, resume: true}},
+        socket
+      ) do
+    %{channel: channel} = socket.assigns
+
+    {:noreply, if video.user_id == channel.user_id do
+      socket
+      |> assign(channel: %{channel | is_live: true})
+    else
+      socket
+    end}
   end
 
   def handle_info(

--- a/lib/algora_web/live/video_live.ex
+++ b/lib/algora_web/live/video_live.ex
@@ -704,7 +704,7 @@ defmodule AlgoraWeb.VideoLive do
         socket
       ) do
     {:noreply,
-     socket = if video.user_id == socket.assigns.channel.user_id do
+     if video.user_id == socket.assigns.channel.user_id do
        socket
        |> stream_insert(:videos, video, at: 0)
      else
@@ -718,12 +718,13 @@ defmodule AlgoraWeb.VideoLive do
       ) do
     %{channel: channel} = socket.assigns
 
-    {:noreply, if video.user_id == channel.user_id do
-      socket
-      |> assign(channel: %{channel | is_live: true})
-    else
-      socket
-    end}
+    {:noreply,
+     if video.user_id == channel.user_id do
+       socket
+       |> assign(channel: %{channel | is_live: true})
+     else
+       socket
+     end}
   end
 
   def handle_info(


### PR DESCRIPTION
This PR adds:

* A synchronized clock, derived from the RTMP source bin, which seems to fix any of the buffer gap errors that would sometimes happen after reconnecting. 

* Fixes the artificial 'pause' when a streamer reconnects by adding a `:resumed` stream state, no longer sending any flash notice on reconnect to the player.

* Fixes finalizing the playlists before terminating

* Configures HLS.js mostly back to it's defaults, except for playlist loading timeouts. This fixes 'short playlist' errors at the start of a stream, allowing faster playlist retries

* keeps more partial segment metadata in memory, allowing retries for partial segments to succeed. This delays deleting partial segments by 24 full segments


The smoothest playback is with a recently updated HLS.js that includes their `feature/preload-hint` branch. A PR for that is available here: algora-io/hls.js#1 