### PR TITLE
Fix error when finializing stream

### DIFF
--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -314,10 +314,8 @@ defmodule Algora.Library do
     )
 
     Repo.update_all(
-      from(v in Video,
-        where: v.user_id == ^video.user_id and (v.id != ^video.id or not (^is_live))
-      ),
-      set: [is_live: false]
+      from(v in Video, where: v.user_id == ^video.user_id and (v.id == ^video.id or v.is_live)),
+      set: [is_live: dynamic([v], v.id == ^video.id and ^is_live)]
     )
 
     video = get_video!(video.id)

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -303,26 +303,7 @@ defmodule Algora.Library do
 
   @type stream_status :: :live | :paused | :resumed | :stopped
 
-  @spec maybe_update_duration(Ecto.Changeset.t(), stream_status) :: Ecto.Changeset.t()
-  defp maybe_update_duration(changeset, status)
-    when status in [:live, :resumed], do: changeset
-
-  defp maybe_update_duration(changeset, _) do
-    with {:ok, duration} <- get_duration(changeset.data),
-         changeset <- changeset |> put_change(:duration, duration) do
-      changeset
-    end
-  end
-
-  @spec maybe_update_url(Ecto.Changeset.t(), stream_status) :: Ecto.Changeset.t()
-  defp maybe_update_url(changeset, :stopped) do
-    changeset |> put_change(:url, Video.url(:vod, changeset.data.uuid, changeset.data.filename))
-  end
-
-  defp maybe_update_url(changeset, _), do: changeset
-
   @spec toggle_stream_status(%Video{}, stream_status) :: :ok
-
   def toggle_stream_status(%Video{} = video, status) do
     video = get_video!(video.id)
     user = Accounts.get_user!(video.user_id)

--- a/lib/algora/library.ex
+++ b/lib/algora/library.ex
@@ -323,14 +323,12 @@ defmodule Algora.Library do
     video = get_video!(video.id)
 
     if status == :stopped do
-      with {:ok, duration} <- get_duration(video),
-           {:ok, video} <-
-             video
-             |> change()
-             |> put_change(:duration, duration)
-             |> put_change(:url, Video.url(:vod, video.uuid, video.filename))
-             |> Repo.update() do
+      with {:ok, duration} <- get_duration(video) do
         video
+        |> change()
+        |> put_change(:duration, duration)
+        |> put_change(:url, Video.url(:vod, video.uuid, video.filename))
+        |> Repo.update()
       end
     end
 

--- a/lib/algora/pipeline/client_handler.ex
+++ b/lib/algora/pipeline/client_handler.ex
@@ -49,6 +49,7 @@ defmodule Algora.Pipeline.ClientHandler do
   @impl true
   def handle_delete_stream(state) do
     if state.source_pid != nil, do: send(state.source_pid, :delete_stream)
+    send(state.pipeline, :delete_stream)
     state
   end
 


### PR DESCRIPTION
This PR fixes an error where a stream never gets a 'duration' and therefore never ends.