### PR TITLE
Use dynamic supervisor unstead of FLAME local backend

### DIFF
--- a/lib/algora/application.ex
+++ b/lib/algora/application.ex
@@ -28,6 +28,8 @@ defmodule Algora.Application do
       {Task.Supervisor, name: Algora.TaskSupervisor},
       # Start the supervisor for tracking manifest uploads
       {DynamicSupervisor, strategy: :one_for_one, name: Algora.Pipeline.Storage.ManifestSupervisor},
+      # Start the supervisor for rtmp to hls pipeline
+      {DynamicSupervisor, strategy: :one_for_one, name: Algora.Pipeline.Supervisor},
       # Start the RPC server
       {Fly.RPC, []},
       # Start the Ecto repository
@@ -39,15 +41,17 @@ defmodule Algora.Application do
       # Start the Telemetry supervisor
       AlgoraWeb.Telemetry,
       # Pipeline flame pool
-      {FLAME.Pool,
-        name: Algora.Pipeline.Pool,
-        backend: Algora.config([:flame_backend]),
-        min: Algora.config([:flame, :min]),
-        max: Algora.config([:flame, :max]),
-        max_concurrency: Algora.config([:flame, :max_concurrency]),
-        idle_shutdown_after: Algora.config([:flame, :idle_shutdown_after]),
-        log: Algora.config([:flame, :log]),
-      },
+      if Algora.config([:flame, :backend]) == FLAME.LocalBackend do
+        {FLAME.Pool,
+          name: Algora.Pipeline.Pool,
+          backend: Algora.config([:flame_backend]),
+          min: Algora.config([:flame, :min]),
+          max: Algora.config([:flame, :max]),
+          max_concurrency: Algora.config([:flame, :max_concurrency]),
+          idle_shutdown_after: Algora.config([:flame, :idle_shutdown_after]),
+          log: Algora.config([:flame, :log]),
+        }
+      end,
       # Start the PubSub system
       {Phoenix.PubSub, name: Algora.PubSub},
       # Start presence

--- a/lib/algora/application.ex
+++ b/lib/algora/application.ex
@@ -41,7 +41,7 @@ defmodule Algora.Application do
       # Start the Telemetry supervisor
       AlgoraWeb.Telemetry,
       # Pipeline flame pool
-      if Algora.config([:flame, :backend]) == FLAME.LocalBackend do
+      if Algora.config([:flame, :backend]) != FLAME.LocalBackend do
         {FLAME.Pool,
           name: Algora.Pipeline.Pool,
           backend: Algora.config([:flame_backend]),

--- a/lib/algora/pipeline/manager.ex
+++ b/lib/algora/pipeline/manager.ex
@@ -16,7 +16,11 @@ defmodule Algora.Pipeline.Manager do
         {:ok, pid}
       else
         _ ->
-          FLAME.place_child(Algora.Pipeline.Pool, {__MODULE__, [self(), params]})
+          if Algora.config([:flame, :backend]) == FLAME.LocalBackend do
+            Algora.Pipeline.Supervisor.start_child([self(), params])
+          else
+            FLAME.place_child(Algora.Pipeline.Pool, {__MODULE__, [self(), params]})
+          end
       end
 
     {Algora.Pipeline.ClientHandler, %{pipeline: pid}}

--- a/lib/algora/pipeline/supervisor.ex
+++ b/lib/algora/pipeline/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Algora.Pipeline.Supervisor do
+  use DynamicSupervisor
+
+  def resume_rtmp(pipeline, params) when is_pid(pipeline) do
+    GenServer.call(pipeline, {:resume_rtmp, params})
+  end
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  def start_child(init_arg) do
+    spec = Supervisor.child_spec({Algora.Pipeline.Manager, init_arg}, restart: :transient)
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+
+  @impl true
+  def init(init_arg) do
+    DynamicSupervisor.init(strategy: :simple_one_for_one, extra_arguments: [init_arg])
+  end
+end


### PR DESCRIPTION
The documentation for [FLAME.LocalBackend](https://hexdocs.pm/flame/FLAME.LocalBackend.html) says it's for development and testing. Currently FLAME.LocalBackend is the only option when running the app when not on Fly's infrastructure while using FLAME.FlyBackend

This PR adds a DynamicSupervisor to supervise pipelines instead of relying on FLAME's LocalBackend. Spawning pipelines when using FLAME.FlyBackend remains unchanged. 